### PR TITLE
Support enum only structs

### DIFF
--- a/src/main/resources/cpp-modern-json/model-header.mustache
+++ b/src/main/resources/cpp-modern-json/model-header.mustache
@@ -29,6 +29,13 @@ struct {{classname}} {
     static void to_json(::nlohmann::json& j, const {{classname}}& obj);
     static void from_json(const ::nlohmann::json& j, {{classname}}& obj);
 
+{{#isEnum}}
+    enum class {{classname}} {
+{{#allowableValues}}{{#enumVars}}        {{name}}{{^-last}},{{/-last}}
+{{/enumVars}}{{/allowableValues}}    };
+
+{{/isEnum}}
+
 {{#hasEnums}}    // enums
 {{#vars}}{{#isEnum}}{{#description}}    /**
      * \brief {{description}}


### PR DESCRIPTION
There is a difference between `isEnum` and `hasEnum`.
A DTO that is defined like this:
```
    "Action": {
        "enum": [
          "ADD",
          "REMOVE"
        ],
        "type": "string"
      },
```
Does not return anything for `hasEnum`.
This PR adds some special treatment for those cases.